### PR TITLE
wikifil: escape braces in regex

### DIFF
--- a/data/wikifil.pl
+++ b/data/wikifil.pl
@@ -31,8 +31,8 @@ while (<>) {
     s/\[\[category:([^|\]]*)[^]]*\]\]/[[$1]]/ig;  # show categories without markup
     s/\[\[[a-z\-]*:[^\]]*\]\]//g;  # remove links to other languages
     s/\[\[[^\|\]]*\|/[[/g;  # remove wiki url, preserve visible text
-    s/{{[^}]*}}//g;         # remove {{icons}} and {tables}
-    s/{[^}]*}//g;
+    s/\{\{[^\}]*\}\}//g;         # remove {{icons}} and {tables}
+    s/\{[^\}]*\}//g;
     s/\[//g;                # remove [ and ]
     s/\]//g;
     s/&[^;]*;/ /g;          # remove URL encoded chars


### PR DESCRIPTION
Hi,

I'm using Perl in version 5.26.1 and the following error message appeared in the preprocessing step:

```bash
[stefan@fedora-dev Word2Bits]$ perl data/wikifil.pl enwik8 > text8
Unescaped left brace in regex is illegal here in regex; marked by <-- HERE in m/{{ <-- HERE [^}]*}}/ at data/wikifil.pl line 34.
```

With this PR braces are escaped in `data/wikifil.pl`. E.g. `fastText` had the same issue with that script and it was fixed [here](https://github.com/facebookresearch/fastText/commit/3e4a9011cc1e346bad6ab390cbea9cc13465f1a8).